### PR TITLE
Run tests from a given line

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,13 @@ Finds and runs a test file from an associated source file.
 
 ## Compilation
 
+Build the plugin to install to Windsurf:
+
 ```bash
 npm install
 npm run build
-vsce package
+npm run vsce:package
+windsurf --install-extension ovsx-test-file-0.0.1.vsix
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ windsurf --install-extension ovsx-test-file-0.0.1.vsix
 ```bash
 npm install
 npm run build
+npm run test
 ```
 
 ## References

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "glob": "^11.0.1"
+        "glob": "^11.0.1",
+        "typescript": "^5.0.0"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.6",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "compile": "tsc -p ./",
     "build": "tsc -p . && tsc -p ./tsconfig.test.json",
-    "test": "node ./out/test/runTest.js",
+    "test": "rm -rf out && npm run build && node ./out/test/runTest.js",
     "lint": "eslint src/**/*.ts test/**/*.ts",
     "vsce:package": "vsce package --no-yarn --githubBranch main"
   },
@@ -23,19 +23,19 @@
     "commands": [
       {
         "command": "testFile.run",
-        "title": "Run all the tests in the current file"
+        "title": "Test File: Run all the tests"
       },
       {
         "command": "testFile.runPrevious",
-        "title": "Run the previous test(s)"
+        "title": "Test File: Run the previous test"
       },
       {
         "command": "testFile.runLine",
-        "title": "Run the test on the current line"
+        "title": "Test File: Run the test from the current line"
       },
       {
         "command": "testFile.runSuite",
-        "title": "Run all tests in the suite"
+        "title": "Test File: Run all tests in the suite"
       }
     ],
     "configuration": {
@@ -63,7 +63,8 @@
     }
   },
   "dependencies": {
-    "glob": "^11.0.1"
+    "glob": "^11.0.1",
+    "typescript": "^5.0.0"
   },
   "repository": {
     "type": "git",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,13 +1,23 @@
 import * as vscode from "vscode";
 import * as terminal from "./terminal";
+import * as utils from "./utils";
 
 export function activate(context: vscode.ExtensionContext): void {
 
   console.log("Open VSX Test File plugin activated");
 
+  // Execute the test file in the terminal
   context.subscriptions.push(vscode.commands.registerCommand("testFile.run", () => terminal.executeTestFile({})));
+
+  // Execute the test file in the terminal from a specific line
+  context.subscriptions.push(vscode.commands.registerCommand("testFile.runLine", async () => terminal.executeTestFile({
+    lineNumber: vscode.window.activeTextEditor?.selection.active.line,
+    currentFunction: (await utils.getCurrentFunctionName()) || undefined
+  })));
+
+  // Execute the previous test file in the terminal
   context.subscriptions.push(vscode.commands.registerCommand("testFile.runPrevious", () => terminal.executeLastTestFile()));
 }
 
 // This function is called when the extension is deactivated
-export function deactivate() {}
+export function deactivate(): void {}

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -4,6 +4,7 @@ interface RunOptions {
   path?: string;
   lineNumber?: number;
   commandText?: string;
+  currentFunction?: string | undefined;
 }
 
 const SPEC_TERMINAL_NAME = 'Test Runner';
@@ -33,7 +34,6 @@ export function executeLastTestFile(): void {
 //
 // Private functions
 //
-
 
 function executeInTerminal(path: string, options: RunOptions): void {
   const specTerminal = getOrCreateTerminal(SPEC_TERMINAL_NAME);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,43 @@
+import * as vscode from 'vscode';
+
+export async function getCurrentFunctionName(): Promise<string | undefined> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+        return undefined;
+    }
+
+    const document = editor.document;
+    const position = editor.selection.active;
+
+    // Get all symbols in the document
+    const symbols = await vscode.commands.executeCommand<vscode.DocumentSymbol[]>(
+        'vscode.executeDocumentSymbolProvider',
+        document.uri
+    );
+
+    if (!symbols) {
+        return undefined;
+    }
+
+    // Find the innermost symbol containing the current position
+    function findContainingSymbol(symbols: vscode.DocumentSymbol[]): vscode.DocumentSymbol | undefined {
+        for (const symbol of symbols) {
+            if (symbol.range.contains(position)) {
+                // Check children first to get the most specific symbol
+                const childSymbol = findContainingSymbol(symbol.children);
+                if (childSymbol) {
+                    return childSymbol;
+                }
+                // If no matching child found, return this symbol if it's a function/method
+                if (symbol.kind === vscode.SymbolKind.Function || 
+                    symbol.kind === vscode.SymbolKind.Method) {
+                    return symbol;
+                }
+            }
+        }
+        return undefined;
+    }
+
+    const symbol = findContainingSymbol(symbols);
+    return symbol?.name;
+}

--- a/test/suite/extension.test.ts
+++ b/test/suite/extension.test.ts
@@ -1,5 +1,6 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
+import * as path from 'path';
 import { executeTestFile } from '../../src/terminal';
 import * as sinon from 'sinon';
 
@@ -7,24 +8,69 @@ describe('Extension Test Suite', function () {
   this.timeout(10000); // 10 second timeout
   vscode.window.showInformationMessage('Start all tests.');
 
-  it('Command exists', async () => {
+  it('has a complete set of tests', async () => {
     // Wait for the extension to be activated
     await vscode.extensions.getExtension('your-publisher-id.ovsx-test-file')?.activate();
     const commands = await vscode.commands.getCommands();
     assert.ok(commands.includes('testFile.run'));
+    assert.ok(commands.includes('testFile.runLine'));
   });
 
-  context('when there is no activeTextEditor', () => {
-    it('shows an error message', async () => {
-      const spy = sinon.spy(vscode.window, 'showErrorMessage');
-      const getActiveTextEditorStub = sinon.stub(vscode.window, 'activeTextEditor').get(() => undefined);
+  context('when testing the entire file', () => {
 
-      await executeTestFile({});
+    context('if there is no activeTextEditor', () => {
 
-      assert.ok(spy.calledWith('No active file to test'));
+      it('shows an error message', async () => {
+        const spy = sinon.spy(vscode.window, 'showErrorMessage');
+        const getActiveTextEditorStub = sinon.stub(vscode.window, 'activeTextEditor').get(() => undefined);
 
-      spy.restore();
-      getActiveTextEditorStub.restore();
+        executeTestFile({});
+
+        assert.ok(spy.calledWith('No active file to test'));
+
+        spy.restore();
+        getActiveTextEditorStub.restore();
+      });
+
     });
+
+    context('if there is an activeTextEditor', () => {
+
+      it('executes the command in the terminal', async () => {
+        const createTerminalSpy = sinon.spy(vscode.window, 'createTerminal');
+
+        // Track if the getter was accessed by using a counter
+        let getterAccessCount = 0;
+        const expectedEditorStub = {
+          document: {
+            uri: vscode.Uri.file(path.join(__dirname, 'fixtures', 'sample-project', 'src', 'main.test.ts')),
+            fsPath: path.join(__dirname, 'fixtures', 'sample-project', 'src', 'main.test.ts')
+          }
+        };
+
+        const getActiveTextEditorStub = sinon.stub(vscode.window, 'activeTextEditor').get(() => {
+          getterAccessCount++;
+          return expectedEditorStub;
+        });
+
+        executeTestFile({});
+
+        assert.ok(getterAccessCount > 0, 'Expected activeTextEditor getter to be accessed');
+        assert.ok(createTerminalSpy.called, 'Expected terminal to be created');
+
+        createTerminalSpy.restore();
+        getActiveTextEditorStub.restore();
+      });
+
+    });
+
   });
+
+  context('when testing a single line or function', () => {
+
+    it('TBD', () => {
+    });
+
+  });
+
 });


### PR DESCRIPTION
Uses the line number from the file, which works in RSpec and any other library that supports line numbers, but it does not work with Python.